### PR TITLE
Create `.git` directory if it does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-require('fs').appendFile('.git/config', `
+const fs = require("fs");
+fs.existsSync(".gitaa") || fs.mkdirSync(".gitaa");
+fs.appendFile('.git/config', `
 [user]
 	name = github-actions[bot]
 	email = 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
When I run this with `nektos/act`, the script fails because it is trying to create a file in a nonexistent `.git` directory.

This makes sure the directory exists.